### PR TITLE
TYPO3 7.6 Compatibility

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,6 +8,7 @@ filter:
 tools:
 
     external_code_coverage:
+        enabled: true
         timeout: 700
 
     php_cpd:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,13 @@ script:
   - >
     echo;
     echo "Running unit tests";
-    .Build/bin/phpunit -c .Build/vendor/typo3/cms/typo3/sysext/core/Build/UnitTests.xml Tests/Unit/
+    .Build/bin/phpunit -c .Build/vendor/typo3/cms/typo3/sysext/core/Build/UnitTests.xml Tests/Unit/ --coverage-text --coverage-clover=coverage.clover
 
   - >
     echo;
     echo "Running php lint";
     find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
+
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,9 @@ php:
 env:
   - TYPO3_VERSION="^6.2.0"
   - TYPO3_VERSION="^7.6.0"
-  - TYPO3_VERSION="dev-master"
 
 matrix:
   exclude:
-    - php: 5.6
-      env: TYPO3_VERSION="dev-master"
     - php: 7
       env: TYPO3_VERSION="^6.2.0"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,31 @@
 language: php
 
 php:
+  - 5.4
+  - 5.5
   - 5.6
-  - 7
+  - hhvm
+  - 7.0
 
 env:
   - TYPO3_VERSION="^6.2.0"
   - TYPO3_VERSION="^7.6.0"
 
 matrix:
+  allow_failures:
+    - php: hhvm
+  fast_finish: true
   exclude:
-    - php: 7
+    # TYPO3 6.2 only with PHP-Versions 5.4 - 5.6
+    - php: 7.0
       env: TYPO3_VERSION="^6.2.0"
+    - php: hhvm
+      env: TYPO3_VERSION="^6.2.0"
+    - php: nightly
+      env: TYPO3_VERSION="^6.2.0"
+    # TYPO3 7.6 only with PHP-Versions 5.5 - 7.0
+    - php: 5.4
+      env: TYPO3_VERSION="^7.6.0"
 
 sudo: false
 
@@ -49,11 +63,3 @@ script:
     echo;
     echo "Running php lint";
     find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
-
-  - >
-    echo;
-    export typo3DatabaseName="typo3";
-    export typo3DatabaseHost="localhost";
-    export typo3DatabaseUsername="root";
-    export typo3DatabasePassword="";
-    find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo "Running functional test suite {}"; .Build/bin/phpunit --colors  -c .Build/vendor/typo3/cms/typo3/sysext/core/Build/FunctionalTests.xml {}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.6
   - hhvm
   - 7.0
+  - nightly
 
 env:
   - TYPO3_VERSION="^6.2.0"
@@ -14,6 +15,7 @@ env:
 matrix:
   allow_failures:
     - php: hhvm
+    - php: nightly
   fast_finish: true
   exclude:
     # TYPO3 6.2 only with PHP-Versions 5.4 - 5.6
@@ -40,7 +42,7 @@ cache:
 
 notifications:
   email:
-    - breakpoint@schreibersebastian.de
+    - typo3@skyfillers.com
 
 before_script:
   - phpenv config-rm xdebug.ini || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,11 @@ notifications:
     - breakpoint@schreibersebastian.de
 
 before_install:
-  - phpenv config-rm xdebug.ini
   - composer self-update
   - composer --version
 
 before_script:
+  - phpenv config-rm xdebug.ini || true
   - composer require typo3/cms="$TYPO3_VERSION"
   # Restore composer.json
   - git checkout composer.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,27 @@
 language: php
+
 php:
-  - 5.4
-  - 5.5
   - 5.6
-  - hhvm
-  - nightly
+  - 7
 
 env:
-  matrix:
-    - DB=mysql TYPO3_BRANCH=TYPO3_6-2 COVERAGE=0
-    - DB=mysql TYPO3_BRANCH=master COVERAGE=0
-  global:
-    secure: pj0LN2iXMab1i05K7MA7KRBhZ3zjVtDWLMPXm10wwCKWvA1jrn8ef9MwO/MuMgZc+ohQF89fkIHHjxJCOiitYwWgMd1o7Qt2QIcWEXmbE1qylHNo48LhBOSRzc24tWVEcPoay1HfR0kteTkJ64kW3f1Dn0bsoN4vqYXeFLrC9hY=
+  - TYPO3_VERSION="^6.2.0"
+  - TYPO3_VERSION="^7.6.0"
+  - TYPO3_VERSION="dev-master"
 
 matrix:
-  allow_failures:
-    - php: hhvm
-    - php: nightly
-  fast_finish: true
-  include:
-    - php: 5.6
-      env: DB=mysql TYPO3_BRANCH=master COVERAGE=1
   exclude:
-    - php: 5.4
-      env: DB=mysql TYPO3_BRANCH=master COVERAGE=0
+    - php: 5.6
+      env: TYPO3_VERSION="dev-master"
+    - php: 7
+      env: TYPO3_VERSION="^6.2.0"
 
 sudo: false
+
+addons:
+  apt:
+    packages:
+      - parallel
 
 cache:
   directories:
@@ -33,37 +29,34 @@ cache:
 
 notifications:
   email:
-    - typo3@skyfillers.com
+    - breakpoint@schreibersebastian.de
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - composer self-update
+  - composer --version
 
 before_script:
-  - cd ..
-  - mkdir parallel && cd parallel && wget http://ftp.gnu.org/gnu/parallel/parallel-latest.tar.bz2 && tar xvf parallel-latest.tar.bz2 -C . --strip-components=1 && ./configure && make && cd ..
-  - git clone --single-branch --branch $TYPO3_BRANCH --depth 1 https://github.com/TYPO3/TYPO3.CMS.git typo3_core
-  - mv typo3_core/* .
-  - if [ "$GITHUB_COMPOSER_AUTH" ]; then composer config -g github-oauth.github.com $GITHUB_COMPOSER_AUTH; fi
-  - composer self-update
-  - composer install
-  - mkdir -p uploads typo3temp typo3conf/ext
-  - mv sf_simple_faq typo3conf/ext/
+  - composer require typo3/cms="$TYPO3_VERSION"
+  # Restore composer.json
+  - git checkout composer.json
+  - export TYPO3_PATH_WEB=$PWD/.Build/Web
 
 script:
   - >
-    if [[ "$COVERAGE" == "0" ]]; then
-      echo;
-      echo "Running unit tests";
-      ./bin/phpunit --colors -c typo3conf/ext/sf_simple_faq/Tests/Build/UnitTests.xml
-    fi
+    echo;
+    echo "Running unit tests";
+    .Build/bin/phpunit -c .Build/vendor/typo3/cms/typo3/sysext/core/Build/UnitTests.xml Tests/Unit/
+
   - >
-    if [[ "$COVERAGE" == "1" ]]; then
-      echo;
-      echo "Running unit tests";
-      ./bin/phpunit --coverage-clover=unittest-coverage.clover --colors -c typo3conf/ext/sf_simple_faq/Tests/Build/UnitTests.xml
-    fi
+    echo;
+    echo "Running php lint";
+    find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
+
   - >
-    if [[ "$COVERAGE" == "1" ]]; then
-      echo;
-      echo "Uploading code coverage results";
-      wget https://scrutinizer-ci.com/ocular.phar
-      cp -R typo3conf/ext/sf_simple_faq/.git .
-      php ocular.phar code-coverage:upload --format=php-clover unittest-coverage.clover;
-    fi
+    echo;
+    export typo3DatabaseName="typo3";
+    export typo3DatabaseHost="localhost";
+    export typo3DatabaseUsername="root";
+    export typo3DatabasePassword="";
+    find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo "Running functional test suite {}"; .Build/bin/phpunit --colors  -c .Build/vendor/typo3/cms/typo3/sysext/core/Build/FunctionalTests.xml {}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ php:
 env:
   - TYPO3_VERSION="^6.2.0"
   - TYPO3_VERSION="^7.6.0"
-  global:
-    secure: pj0LN2iXMab1i05K7MA7KRBhZ3zjVtDWLMPXm10wwCKWvA1jrn8ef9MwO/MuMgZc+ohQF89fkIHHjxJCOiitYwWgMd1o7Qt2QIcWEXmbE1qylHNo48LhBOSRzc24tWVEcPoay1HfR0kteTkJ64kW3f1Dn0bsoN4vqYXeFLrC9hY=
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ php:
 env:
   - TYPO3_VERSION="^6.2.0"
   - TYPO3_VERSION="^7.6.0"
+  global:
+    secure: pj0LN2iXMab1i05K7MA7KRBhZ3zjVtDWLMPXm10wwCKWvA1jrn8ef9MwO/MuMgZc+ohQF89fkIHHjxJCOiitYwWgMd1o7Qt2QIcWEXmbE1qylHNo48LhBOSRzc24tWVEcPoay1HfR0kteTkJ64kW3f1Dn0bsoN4vqYXeFLrC9hY=
 
 matrix:
   allow_failures:
@@ -42,12 +44,10 @@ notifications:
   email:
     - breakpoint@schreibersebastian.de
 
-before_install:
-  - composer self-update
-  - composer --version
-
 before_script:
   - phpenv config-rm xdebug.ini || true
+  - composer self-update
+  - composer --version
   - composer require typo3/cms="$TYPO3_VERSION"
   # Restore composer.json
   - git checkout composer.json

--- a/Classes/Service/SettingsService.php
+++ b/Classes/Service/SettingsService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Skyfillers\SfSimpleFaq\Service;
+namespace SKYFILLERS\SfSimpleFaq\Service;
 /***************************************************************
  *  Copyright notice
  *

--- a/Classes/Service/SettingsService.php
+++ b/Classes/Service/SettingsService.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace SKYFILLERS\SfSimpleFaq\Service;
+
 /***************************************************************
  *  Copyright notice
  *
@@ -43,39 +44,41 @@ use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
  *
  * @author Stefano Kowalke <s.kowalke@skyfillers.com>
  */
-class SettingsService implements SingletonInterface {
-
+class SettingsService implements SingletonInterface
+{
+	
 	/**
 	 * @var mixed
 	 */
-	protected $configuration = null;
-
-    /**
-     * @var array
-     */
-	protected $configurationPathCache = array();
-
+	protected $configuration;
+	
+	/**
+	 * @var array
+	 */
+	protected $configurationPathCache = [];
+	
 	/**
 	 * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
 	 * @inject
 	 */
 	protected $configurationManager;
-
+	
 	/**
 	 * Returns the TS configuration
 	 *
 	 * @return array|mixed
 	 */
-	public function getConfiguration() {
-		if ($this->configuration === NULL) {
+	public function getConfiguration()
+	{
+		if ($this->configuration === null) {
 			$this->configuration = $this->configurationManager->getConfiguration(
 				ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK
 			);
 		}
-
+		
 		return $this->configuration;
 	}
-
+	
 	/**
 	 * Returns the settings at path $path, which is separated by ".",
 	 * e.g. "pages.uid".
@@ -84,34 +87,36 @@ class SettingsService implements SingletonInterface {
 	 * If the path is invalid or no entry is found, false is returned.
 	 *
 	 * @param string $path
+	 *
 	 * @return mixed
 	 */
-	public function getByPath($path) {
-
-	    if(isset($this->configurationPathCache[$path])) {
-	        return $this->configurationPathCache[$path];
-        }
-
+	public function getByPath($path)
+	{
+		
+		if (isset($this->configurationPathCache[$path])) {
+			return $this->configurationPathCache[$path];
+		}
+		
 		$configuration = $this->getConfiguration();
-
+		
 		$setting = $this->getPropertyPath($configuration, $path);
-		if ($setting === NULL) {
+		if ($setting === null) {
 			$setting = $this->getPropertyPath($configuration['settings'], $path);
 		}
-
+		
 		$this->configurationPathCache[$path] = $setting;
-
+		
 		return $setting;
 	}
-
-    /**
-     * @param array $configuration
-     * @param string $path
-     *
-     * @return mixed
-     */
+	
+	/**
+	 * @param array $configuration
+	 * @param string $path
+	 *
+	 * @return mixed
+	 */
 	protected function getPropertyPath(array $configuration, $path)
-    {
-        return ObjectAccess::getPropertyPath($configuration, $path);
-    }
+	{
+		return ObjectAccess::getPropertyPath($configuration, $path);
+	}
 }

--- a/Classes/Service/SettingsService.php
+++ b/Classes/Service/SettingsService.php
@@ -44,10 +44,16 @@ use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
  * @author Stefano Kowalke <s.kowalke@skyfillers.com>
  */
 class SettingsService implements SingletonInterface {
+
 	/**
 	 * @var mixed
 	 */
-	protected $configuration;
+	protected $configuration = null;
+
+    /**
+     * @var array
+     */
+	protected $configurationPathCache = array();
 
 	/**
 	 * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
@@ -81,13 +87,31 @@ class SettingsService implements SingletonInterface {
 	 * @return mixed
 	 */
 	public function getByPath($path) {
+
+	    if(isset($this->configurationPathCache[$path])) {
+	        return $this->configurationPathCache[$path];
+        }
+
 		$configuration = $this->getConfiguration();
 
-		$setting = ObjectAccess::getPropertyPath($configuration, $path);
+		$setting = $this->getPropertyPath($configuration, $path);
 		if ($setting === NULL) {
-			$setting = ObjectAccess::getPropertyPath($configuration['settings'], $path);
+			$setting = $this->getPropertyPath($configuration['settings'], $path);
 		}
+
+		$this->configurationPathCache[$path] = $setting;
 
 		return $setting;
 	}
+
+    /**
+     * @param array $configuration
+     * @param string $path
+     *
+     * @return mixed
+     */
+	protected function getPropertyPath(array $configuration, $path)
+    {
+        return ObjectAccess::getPropertyPath($configuration, $path);
+    }
 }

--- a/Classes/ViewHelpers/HighlightSearchwordViewHelper.php
+++ b/Classes/ViewHelpers/HighlightSearchwordViewHelper.php
@@ -13,10 +13,7 @@ namespace SKYFILLERS\SfSimpleFaq\ViewHelpers;
  *
  * The TYPO3 project - inspiring people to share!
  */
-use Psr\Log\InvalidArgumentException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Mvc\Exception\InvalidActionNameException;
-use TYPO3\CMS\Extbase\Mvc\Exception\InvalidViewHelperException;
 
 /**
  * Class HighlightSearchwordViewHelper

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,22 @@
+<?php
+
+if (!defined('TYPO3_MODE')) {
+    die('Access denied.');
+}
+
+\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
+    'sf_simple_faq',
+    'Pifaq',
+    'Simple FAQ'
+);
+
+/* Add Flexform */
+$extensionName = \TYPO3\CMS\Core\Utility\GeneralUtility::underscoredToUpperCamelCase('sf_simple_faq');
+$pluginSignature = strtolower($extensionName) . '_pifaq';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($pluginSignature, 'FILE:EXT:sf_simple_faq/Configuration/FlexForms/Flexform_plugin.xml');
+
+/* Static TypoScript */
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('sf_simple_faq', 'Configuration/TypoScript', 'Simple FAQ');
+
+

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,22 +1,24 @@
 <?php
 
 if (!defined('TYPO3_MODE')) {
-    die('Access denied.');
+	die('Access denied.');
 }
 
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-    'sf_simple_faq',
-    'Pifaq',
-    'Simple FAQ'
+	'sf_simple_faq',
+	'Pifaq',
+	'Simple FAQ'
 );
 
 /* Add Flexform */
 $extensionName = \TYPO3\CMS\Core\Utility\GeneralUtility::underscoredToUpperCamelCase('sf_simple_faq');
-$pluginSignature = strtolower($extensionName) . '_pifaq';
+$pluginSignature = strtolower($extensionName).'_pifaq';
 $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($pluginSignature, 'FILE:EXT:sf_simple_faq/Configuration/FlexForms/Flexform_plugin.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($pluginSignature,
+	'FILE:EXT:sf_simple_faq/Configuration/FlexForms/Flexform_plugin.xml');
 
 /* Static TypoScript */
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('sf_simple_faq', 'Configuration/TypoScript', 'Simple FAQ');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('sf_simple_faq', 'Configuration/TypoScript',
+	'Simple FAQ');
 
 

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,9 +1,18 @@
 
 plugin.tx_sfsimplefaq {
 	view {
-		templateRootPath = {$plugin.tx_sfsimplefaq.view.templateRootPath}
-		partialRootPath = {$plugin.tx_sfsimplefaq.view.partialRootPath}
-		layoutRootPath = {$plugin.tx_sfsimplefaq.view.layoutRootPath}
+		templateRootPaths {
+			0 = EXT:sf_simple_faq/Resources/Private/Templates/
+			10 = {$plugin.tx_sfsimplefaq.view.templateRootPath}
+		}
+		partialRootPaths {
+			0 = EXT:sf_simple_faq/Resources/Private/Partials/
+			10 = $plugin.tx_sfsimplefaq.view.partialRootPath}
+		}
+		layoutRootPath {
+			0 = EXT:sf_simple_faq/Resources/Private/Layouts/
+			10 = {$plugin.tx_sfsimplefaq.view.layoutRootPath}
+		}
 	}
 	persistence {
 		storagePid = {$plugin.tx_sfsimplefaq.persistence.storagePid}

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -9,7 +9,7 @@ plugin.tx_sfsimplefaq {
 			0 = EXT:sf_simple_faq/Resources/Private/Partials/
 			10 = {$plugin.tx_sfsimplefaq.view.partialRootPath}
 		}
-		layoutRootPath {
+		layoutRootPaths {
 			0 = EXT:sf_simple_faq/Resources/Private/Layouts/
 			10 = {$plugin.tx_sfsimplefaq.view.layoutRootPath}
 		}

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -7,7 +7,7 @@ plugin.tx_sfsimplefaq {
 		}
 		partialRootPaths {
 			0 = EXT:sf_simple_faq/Resources/Private/Partials/
-			10 = $plugin.tx_sfsimplefaq.view.partialRootPath}
+			10 = {$plugin.tx_sfsimplefaq.view.partialRootPath}
 		}
 		layoutRootPath {
 			0 = EXT:sf_simple_faq/Resources/Private/Layouts/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TYPO3 Extension "sf_simple_faq"
 
-[![Build Status](https://travis-ci.org/Skyfillers/sf_simple_faq.svg?branch=master)](https://travis-ci.org/Skyfillers/sf_simple_faq)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Skyfillers/sf_simple_faq/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Skyfillers/sf_simple_faq/?branch=master)
+[![Build Status](https://img.shields.io/travis/sabbelasichon/sf_simple_faq.svg)](https://travis-ci.org/Skyfillers/sf_simple_faq)
+[![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/coverage/g/Skyfillers/sf_simple_faq/master.svg)](https://scrutinizer-ci.com/g/Skyfillers/sf_simple_faq)
 
 ## What is it?
 
@@ -17,7 +17,7 @@ The FAQs are shown in the frontend along with a search field and a category head
 Download the extension from TER or clone from https://github.com/Skyfillers/sf_simple_faq.git into your TYPO3 installation and install it.
 Then add the static TypoScript Template to your root template.
 
-## Configuration
+## Configuration 
 
 After you added the plugin to a page you have to set the Resource Folder at the "Behavior" Tab of the plugin.
 Otherwise you may set the storagePid via TS.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TYPO3 Extension "sf_simple_faq"
 
-[![Build Status](https://img.shields.io/travis/sabbelasichon/sf_simple_faq.svg)](https://travis-ci.org/Skyfillers/sf_simple_faq)
-[![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/coverage/g/Skyfillers/sf_simple_faq/master.svg)](https://scrutinizer-ci.com/g/Skyfillers/sf_simple_faq)
+[![Build Status](https://travis-ci.org/Skyfillers/sf_simple_faq.svg?branch=master)](https://travis-ci.org/Skyfillers/sf_simple_faq)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Skyfillers/sf_simple_faq/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Skyfillers/sf_simple_faq/?branch=master)
 
 ## What is it?
 
@@ -17,7 +17,7 @@ The FAQs are shown in the frontend along with a search field and a category head
 Download the extension from TER or clone from https://github.com/Skyfillers/sf_simple_faq.git into your TYPO3 installation and install it.
 Then add the static TypoScript Template to your root template.
 
-## Configuration 
+## Configuration
 
 After you added the plugin to a page you have to set the Resource Folder at the "Behavior" Tab of the plugin.
 Otherwise you may set the storagePid via TS.
@@ -27,9 +27,3 @@ You then have several Flexform settings which change the behavior of the extensi
 - Show/Hide the category overview
 - Enable/Disable multiple category selection
 - Show the answers in the list view or in a detail view
-
-
-
-
-
-

--- a/Tests/Unit/Service/SettingsServiceTest.php
+++ b/Tests/Unit/Service/SettingsServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+
+namespace SKYFILLERS\SfSimpleFaq\Tests\Unit\Service;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Test case for class \Skyfillers\SfSimpleFaq\Service\SettingsService
+ *
+ * @copyright Copyright belongs to the respective authors
+ * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
+ *
+ * @author Daniel Meyer <d.meyer@skyfillers.com>
+ * @author Jöran Kurschatke <j.kurschatke@skyfillers.com>
+ */
+
+
+class SettingsServiceTest extends \TYPO3\CMS\Core\Tests\UnitTestCase
+{
+
+    /**
+     * @var \Skyfillers\SfSimpleFaq\Service\SettingsService
+     */
+    protected $subject;
+
+    /**
+     * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $configurationManager;
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->subject = new \Skyfillers\SfSimpleFaq\Service\SettingsService();
+        $this->configurationManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManagerInterface')->getMock();
+        $this->inject($this->subject, 'configurationManager', $this->configurationManager);
+    }
+
+    /**
+     * @test
+     */
+    public function getConfigurationInConfigurationManagerOnlyCalledOnce()
+    {
+        $configuration = array('settings' => array('key' => 'value'));
+        $this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
+
+        $this->subject->getByPath('key');
+        $this->subject->getByPath('key');
+        $this->subject->getByPath('key');
+        $this->subject->getByPath('key');
+    }
+
+    /**
+     * @test
+     */
+    public function getSettingFromSettingsSimple()
+    {
+        $configuration = array('settings' => array('key' => 'value'));
+        $this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
+
+        $this->assertEquals('value', $this->subject->getByPath('key'));
+    }
+
+    /**
+     * @test
+     */
+    public function getSettingSimple()
+    {
+        $configuration = array('key' => 'value');
+        $this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
+
+        $this->assertEquals('value', $this->subject->getByPath('key'));
+    }
+
+    /**
+     * @test
+     */
+    public function getSettingWithDots()
+    {
+        $configuration = array('key' => array('path' => 'value'));
+        $this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
+
+        $this->assertEquals('value', $this->subject->getByPath('key.path'));
+    }
+
+    /**
+     * @test
+     */
+    public function getSettingFromCache()
+    {
+        /** @var \Skyfillers\SfSimpleFaq\Service\SettingsService|\PHPUnit_Framework_MockObject_MockObject $settingsService */
+        $settingsService = $this->getMockBuilder('Skyfillers\\SfSimpleFaq\\Service\\SettingsService')->setMethods(array('getPropertyPath'))->getMock();
+        $settingsService->expects($this->once())->method('getPropertyPath')->willReturn('value');
+
+        $configuration = array('settings' => array('key' => 'value'));
+        $this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
+        $this->inject($settingsService, 'configurationManager', $this->configurationManager);
+
+        $settingsService->getByPath('key');
+        $settingsService->getByPath('key');
+    }
+
+}

--- a/Tests/Unit/Service/SettingsServiceTest.php
+++ b/Tests/Unit/Service/SettingsServiceTest.php
@@ -31,7 +31,7 @@ class SettingsServiceTest extends \TYPO3\CMS\Core\Tests\UnitTestCase
 {
 
     /**
-     * @var \Skyfillers\SfSimpleFaq\Service\SettingsService
+     * @var \SKYFILLERS\SfSimpleFaq\Service\SettingsService
      */
     protected $subject;
 
@@ -45,7 +45,7 @@ class SettingsServiceTest extends \TYPO3\CMS\Core\Tests\UnitTestCase
      */
     protected function setUp()
     {
-        $this->subject = new \Skyfillers\SfSimpleFaq\Service\SettingsService();
+        $this->subject = new \SKYFILLERS\SfSimpleFaq\Service\SettingsService();
         $this->configurationManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManagerInterface')->getMock();
         $this->inject($this->subject, 'configurationManager', $this->configurationManager);
     }
@@ -102,8 +102,8 @@ class SettingsServiceTest extends \TYPO3\CMS\Core\Tests\UnitTestCase
      */
     public function getSettingFromCache()
     {
-        /** @var \Skyfillers\SfSimpleFaq\Service\SettingsService|\PHPUnit_Framework_MockObject_MockObject $settingsService */
-        $settingsService = $this->getMockBuilder('Skyfillers\\SfSimpleFaq\\Service\\SettingsService')->setMethods(array('getPropertyPath'))->getMock();
+        /** @var \SKYFILLERS\SfSimpleFaq\Service\SettingsService|\PHPUnit_Framework_MockObject_MockObject $settingsService */
+        $settingsService = $this->getMockBuilder('SKYFILLERS\\SfSimpleFaq\\Service\\SettingsService')->setMethods(array('getPropertyPath'))->getMock();
         $settingsService->expects($this->once())->method('getPropertyPath')->willReturn('value');
 
         $configuration = array('settings' => array('key' => 'value'));

--- a/Tests/Unit/Service/SettingsServiceTest.php
+++ b/Tests/Unit/Service/SettingsServiceTest.php
@@ -22,96 +22,93 @@ namespace SKYFILLERS\SfSimpleFaq\Tests\Unit\Service;
  * @copyright Copyright belongs to the respective authors
  * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
  *
- * @author Daniel Meyer <d.meyer@skyfillers.com>
- * @author Jöran Kurschatke <j.kurschatke@skyfillers.com>
+ * @author Sebastian Schreiber <breakpoint@schreibersebastian.de>
  */
-
-
 class SettingsServiceTest extends \TYPO3\CMS\Core\Tests\UnitTestCase
 {
-
-    /**
-     * @var \SKYFILLERS\SfSimpleFaq\Service\SettingsService
-     */
-    protected $subject;
-
-    /**
-     * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $configurationManager;
-
-    /**
-     * @return void
-     */
-    protected function setUp()
-    {
-        $this->subject = new \SKYFILLERS\SfSimpleFaq\Service\SettingsService();
-        $this->configurationManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManagerInterface')->getMock();
-        $this->inject($this->subject, 'configurationManager', $this->configurationManager);
-    }
-
-    /**
-     * @test
-     */
-    public function getConfigurationInConfigurationManagerOnlyCalledOnce()
-    {
-        $configuration = array('settings' => array('key' => 'value'));
-        $this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
-
-        $this->subject->getByPath('key');
-        $this->subject->getByPath('key');
-        $this->subject->getByPath('key');
-        $this->subject->getByPath('key');
-    }
-
-    /**
-     * @test
-     */
-    public function getSettingFromSettingsSimple()
-    {
-        $configuration = array('settings' => array('key' => 'value'));
-        $this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
-
-        $this->assertEquals('value', $this->subject->getByPath('key'));
-    }
-
-    /**
-     * @test
-     */
-    public function getSettingSimple()
-    {
-        $configuration = array('key' => 'value');
-        $this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
-
-        $this->assertEquals('value', $this->subject->getByPath('key'));
-    }
-
-    /**
-     * @test
-     */
-    public function getSettingWithDots()
-    {
-        $configuration = array('key' => array('path' => 'value'));
-        $this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
-
-        $this->assertEquals('value', $this->subject->getByPath('key.path'));
-    }
-
-    /**
-     * @test
-     */
-    public function getSettingFromCache()
-    {
-        /** @var \SKYFILLERS\SfSimpleFaq\Service\SettingsService|\PHPUnit_Framework_MockObject_MockObject $settingsService */
-        $settingsService = $this->getMockBuilder('SKYFILLERS\\SfSimpleFaq\\Service\\SettingsService')->setMethods(array('getPropertyPath'))->getMock();
-        $settingsService->expects($this->once())->method('getPropertyPath')->willReturn('value');
-
-        $configuration = array('settings' => array('key' => 'value'));
-        $this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
-        $this->inject($settingsService, 'configurationManager', $this->configurationManager);
-
-        $settingsService->getByPath('key');
-        $settingsService->getByPath('key');
-    }
-
+	
+	/**
+	 * @var \SKYFILLERS\SfSimpleFaq\Service\SettingsService
+	 */
+	protected $subject;
+	
+	/**
+	 * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $configurationManager;
+	
+	/**
+	 * @return void
+	 */
+	protected function setUp()
+	{
+		$this->subject = new \SKYFILLERS\SfSimpleFaq\Service\SettingsService();
+		$this->configurationManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManagerInterface')->getMock();
+		$this->inject($this->subject, 'configurationManager', $this->configurationManager);
+	}
+	
+	/**
+	 * @test
+	 */
+	public function getConfigurationInConfigurationManagerOnlyCalledOnce()
+	{
+		$configuration = ['settings' => ['key' => 'value']];
+		$this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
+		
+		$this->subject->getByPath('key');
+		$this->subject->getByPath('key');
+		$this->subject->getByPath('key');
+		$this->subject->getByPath('key');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function getSettingFromSettingsSimple()
+	{
+		$configuration = ['settings' => ['key' => 'value']];
+		$this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
+		
+		$this->assertEquals('value', $this->subject->getByPath('key'));
+	}
+	
+	/**
+	 * @test
+	 */
+	public function getSettingSimple()
+	{
+		$configuration = ['key' => 'value'];
+		$this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
+		
+		$this->assertEquals('value', $this->subject->getByPath('key'));
+	}
+	
+	/**
+	 * @test
+	 */
+	public function getSettingWithDots()
+	{
+		$configuration = ['key' => ['path' => 'value']];
+		$this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
+		
+		$this->assertEquals('value', $this->subject->getByPath('key.path'));
+	}
+	
+	/**
+	 * @test
+	 */
+	public function getSettingFromCache()
+	{
+		/** @var \SKYFILLERS\SfSimpleFaq\Service\SettingsService|\PHPUnit_Framework_MockObject_MockObject $settingsService */
+		$settingsService = $this->getMockBuilder('SKYFILLERS\\SfSimpleFaq\\Service\\SettingsService')->setMethods(['getPropertyPath'])->getMock();
+		$settingsService->expects($this->once())->method('getPropertyPath')->willReturn('value');
+		
+		$configuration = ['settings' => ['key' => 'value']];
+		$this->configurationManager->expects($this->once())->method('getConfiguration')->willReturn($configuration);
+		$this->inject($settingsService, 'configurationManager', $this->configurationManager);
+		
+		$settingsService->getByPath('key');
+		$settingsService->getByPath('key');
+	}
+	
 }

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
   },
   "replace": {
     "sf_simple_faq": "self.version",
-    "skyfillers/sf-simple-faq": "self.version"
+    "typo3-ter/sf-simple-faq": "self.version"
   },
   "extra": {
     "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -29,19 +29,44 @@
     "issues": "https://github.com/Skyfillers/sf_simple_faq/issues"
   },
   "require": {
-    "typo3/cms-core": ">=6.2.0,<7.0"
+    "typo3/cms-core": "^6.2 || ^7.6"
   },
   "autoload": {
     "psr-4": {
       "SKYFILLERS\\SfSimpleFaq\\": "Classes"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "SKYFILLERS\\SfSimpleFaq\\Tests\\": "Tests",
+      "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms/typo3/sysext/core/Tests/",
+      "TYPO3\\CMS\\Fluid\\Tests\\": ".Build/vendor/typo3/cms/typo3/sysext/fluid/Tests/"
+    }
+  },
+  "config": {
+    "vendor-dir": ".Build/vendor",
+    "bin-dir": ".Build/bin",
+    "preferred-install": {
+      "typo3/cms": "source"
+    }
+  },
+  "scripts": {
+    "post-autoload-dump": [
+      "mkdir -p .Build/Web/typo3conf/ext/",
+      "[ -L .Build/Web/typo3conf/ext/sf_simple_faq ] || ln -snvf ../../../../. .Build/Web/typo3conf/ext/sf_simple_faq"
+    ]
+  },
   "replace": {
-    "sf_simple_faq": "*"
+    "sf_simple_faq": "self.version",
+    "skyfillers/sf-simple-faq": "self.version"
   },
   "extra": {
     "branch-alias": {
       "dev-master": "1.2.x-dev"
+    },
+    "typo3/cms": {
+      "cms-package-dir": "{$vendor-dir}/typo3/cms",
+      "web-dir": ".Build/Web"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
   "require": {
     "typo3/cms-core": "^6.2 || ^7.6"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^4.7 || ^5.0"
+  },
   "autoload": {
     "psr-4": {
       "SKYFILLERS\\SfSimpleFaq\\": "Classes"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -21,4 +21,18 @@ $EM_CONF[$_EXTKEY] = array(
 		'suggests' => array(
 		),
 	),
+	'autoload' =>
+		array(
+			'psr-4' =>
+				array(
+					'SKYFILLERS\\SfSimpleFaq\\' => 'Classes',
+				),
+		),
+	'autoload-dev' =>
+		array(
+			'psr-4' =>
+				array(
+					'SKYFILLERS\\SfSimpleFaq\\Tests\\' => 'Tests',
+				),
+		),
 );

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -21,18 +21,14 @@ $EM_CONF[$_EXTKEY] = array(
 		'suggests' => array(
 		),
 	),
-	'autoload' =>
-		array(
-			'psr-4' =>
-				array(
-					'SKYFILLERS\\SfSimpleFaq\\' => 'Classes',
-				),
-		),
-	'autoload-dev' =>
-		array(
-			'psr-4' =>
-				array(
-					'SKYFILLERS\\SfSimpleFaq\\Tests\\' => 'Tests',
-				),
-		),
+	'autoload' => [
+		'psr-4' => [
+			'SKYFILLERS\\SfSimpleFaq\\' => 'Classes',
+		],
+	],
+	'autoload-dev' => [
+		'psr-4' => [
+			'SKYFILLERS\\SfSimpleFaq\\Tests\\' => 'Tests',
+		],
+	],
 );

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,21 +3,6 @@ if (!defined('TYPO3_MODE')) {
 	die('Access denied.');
 }
 
-\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-	$_EXTKEY,
-	'Pifaq',
-	'Simple FAQ'
-);
-
-/* Add Flexform */
-$extensionName = \TYPO3\CMS\Core\Utility\GeneralUtility::underscoredToUpperCamelCase($_EXTKEY);
-$pluginSignature = strtolower($extensionName) . '_pifaq';
-$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($pluginSignature, 'FILE:EXT:' . $_EXTKEY . '/Configuration/FlexForms/Flexform_plugin.xml');
-
-/* Static TypoScript */
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Simple FAQ');
-
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addLLrefForTCAdescr('tx_sfsimplefaq_domain_model_category', 'EXT:sf_simple_faq/Resources/Private/Language/locallang_csh_tx_sfsimplefaq_domain_model_category.xlf');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_sfsimplefaq_domain_model_category');
 


### PR DESCRIPTION
I added and changed several things:

Non BC-Breaks:
- Moved code from ext_tables.php to TCA/Overrides/tt_content.php
- Autoloading section in em_conf.php for non composer mode autoloading sites, will be totally ignored for TYPO3 6.2 installations
- Removed unused use imports in file HighlightSearchwordViewHelper.php
- Modified composer.json so testing for CI is a lot easier and the configuration is more accurate
- SettingsService is now tested and i introduced some kind of internal caching mechanism
- I changed and removed a lot for the travis integration. It is now easier to test the different TYPO3 versions. 
I also removed some PHP checks like the testing agains nightly version. I don´t know if it is needed.

BC-Break
- I changed the TS-Configuration for the partials, layouts and templates. This is a BC-Break and has to be changed individually per installation, if it is used in custom settings.

Disclaimer:
Maybe i changed to much for you. Sorry for that. I´m using this extension in two of my projects which i would like to upgrade to TYPO3 7.6 or already upgraded to.
Please let me now, if i should change something.